### PR TITLE
Add WorkManager-based Gemma model downloader

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -56,6 +56,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.kotlinx.coroutines.android)
+    implementation(libs.androidx.work.runtime.ktx)
 
     implementation(libs.koog.agents) {
         exclude(group = "io.modelcontextprotocol", module = "kotlin-sdk-core-jvm")

--- a/app/src/main/java/com/monday8am/koogagent/local/download/GemmaModelDownloadManager.kt
+++ b/app/src/main/java/com/monday8am/koogagent/local/download/GemmaModelDownloadManager.kt
@@ -1,0 +1,92 @@
+package com.monday8am.koogagent.local.download
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.getWorkInfoByIdFlow
+import androidx.work.workDataOf
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+
+class GemmaModelDownloadManager(
+    context: Context,
+    private val workManager: WorkManager = WorkManager.getInstance(context),
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+
+    fun downloadModel(url: String, destinationFile: File): Flow<DownloadStatus> = channelFlow {
+        val result = withContext(dispatcher) {
+            if (destinationFile.exists()) {
+                destinationFile
+            } else {
+                destinationFile.parentFile?.mkdirs()
+                null
+            }
+        }
+
+        result?.let {
+            send(DownloadStatus.Completed(it))
+            return@channelFlow
+        }
+
+        val workRequest = OneTimeWorkRequestBuilder<GemmaModelDownloadWorker>()
+            .setInputData(
+                workDataOf(
+                    GemmaModelDownloadWorker.KEY_URL to url,
+                    GemmaModelDownloadWorker.KEY_DESTINATION_PATH to destinationFile.absolutePath,
+                ),
+            )
+            .addTag(WORK_TAG)
+            .build()
+
+        send(DownloadStatus.Pending)
+        workManager.enqueueUniqueWork(WORK_NAME, ExistingWorkPolicy.REPLACE, workRequest)
+
+        val job = launch {
+            workManager.getWorkInfoByIdFlow(workRequest.id).collectLatest { info ->
+                send(info.toDownloadStatus(destinationFile))
+            }
+        }
+
+        awaitClose {
+            job.cancel()
+            workManager.cancelWorkById(workRequest.id)
+        }
+    }
+
+    private fun WorkInfo.toDownloadStatus(file: File): DownloadStatus = when (state) {
+        WorkInfo.State.ENQUEUED, WorkInfo.State.BLOCKED -> DownloadStatus.Pending
+        WorkInfo.State.RUNNING -> {
+            val progress = progress.getInt(GemmaModelDownloadWorker.KEY_PROGRESS, -1)
+            DownloadStatus.InProgress(progress.takeIf { it >= 0 })
+        }
+        WorkInfo.State.SUCCEEDED -> DownloadStatus.Completed(file)
+        WorkInfo.State.FAILED -> DownloadStatus.Failed(
+            outputData.getString(GemmaModelDownloadWorker.KEY_ERROR_MESSAGE)
+                ?: "Unknown error",
+        )
+        WorkInfo.State.CANCELLED -> DownloadStatus.Cancelled
+    }
+
+    sealed class DownloadStatus {
+        data object Pending : DownloadStatus()
+        data class InProgress(val progress: Int?) : DownloadStatus()
+        data class Completed(val file: File) : DownloadStatus()
+        data class Failed(val message: String) : DownloadStatus()
+        data object Cancelled : DownloadStatus()
+    }
+
+    companion object {
+        private const val WORK_NAME = "gemma-model-download"
+        private const val WORK_TAG = "gemma-model-download-tag"
+    }
+}

--- a/app/src/main/java/com/monday8am/koogagent/local/download/GemmaModelDownloadWorker.kt
+++ b/app/src/main/java/com/monday8am/koogagent/local/download/GemmaModelDownloadWorker.kt
@@ -1,0 +1,102 @@
+package com.monday8am.koogagent.local.download
+
+import android.content.Context
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.coroutineContext
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
+internal class GemmaModelDownloadWorker(
+    appContext: Context,
+    params: WorkerParameters,
+) : CoroutineWorker(appContext, params) {
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val url = inputData.getString(KEY_URL) ?: return@withContext Result.failure()
+        val destinationPath = inputData.getString(KEY_DESTINATION_PATH) ?: return@withContext Result.failure()
+
+        val destinationFile = File(destinationPath)
+        destinationFile.parentFile?.mkdirs()
+
+        val tempFile = File.createTempFile(destinationFile.name, TEMP_EXTENSION, destinationFile.parentFile)
+
+        try {
+            downloadFile(url, tempFile)
+            if (!tempFile.renameTo(destinationFile)) {
+                tempFile.copyTo(destinationFile, overwrite = true)
+                tempFile.delete()
+            }
+            Result.success()
+        } catch (throwable: Throwable) {
+            tempFile.delete()
+            if (throwable is CancellationException) {
+                throw throwable
+            }
+            Result.failure(workDataOf(KEY_ERROR_MESSAGE to throwable.message))
+        }
+    }
+
+    private suspend fun downloadFile(sourceUrl: String, destinationFile: File) {
+        val connection = (URL(sourceUrl).openConnection() as HttpURLConnection).apply {
+            connectTimeout = CONNECTION_TIMEOUT_MS
+            readTimeout = READ_TIMEOUT_MS
+            requestMethod = "GET"
+            doInput = true
+        }
+
+        try {
+            connection.connect()
+            val contentLength = connection.contentLengthLong.takeIf { it > 0 }
+            setProgress(workDataOf(KEY_PROGRESS to 0))
+
+            connection.inputStream.use { inputStream ->
+                FileOutputStream(destinationFile).use { outputStream ->
+                    copyStream(inputStream, outputStream, contentLength)
+                }
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+
+    private suspend fun copyStream(
+        inputStream: InputStream,
+        outputStream: FileOutputStream,
+        contentLength: Long?,
+    ) {
+        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+        var bytesCopied = 0L
+        while (true) {
+            coroutineContext.ensureActive()
+            val bytesRead = inputStream.read(buffer)
+            if (bytesRead == -1) break
+            outputStream.write(buffer, 0, bytesRead)
+            bytesCopied += bytesRead
+            if (contentLength != null && contentLength > 0) {
+                val progress = ((bytesCopied * 100) / contentLength).toInt().coerceIn(0, 100)
+                setProgress(workDataOf(KEY_PROGRESS to progress))
+            }
+        }
+        outputStream.fd.sync()
+    }
+
+    companion object {
+        const val KEY_URL = "key_url"
+        const val KEY_DESTINATION_PATH = "key_destination_path"
+        const val KEY_PROGRESS = "key_progress"
+        const val KEY_ERROR_MESSAGE = "key_error_message"
+
+        private const val CONNECTION_TIMEOUT_MS = 30_000
+        private const val READ_TIMEOUT_MS = 30_000
+        private const val TEMP_EXTENSION = ".download"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,8 @@ jetbrainsKotlinJvm = "2.2.20"
 koog = "0.4.2"
 mediapipeTasksText = "0.20230731"
 mediapipeTasksGenai = "0.10.29"
+kotlinxCoroutines = "1.9.0"
+workRuntime = "2.10.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,6 +33,8 @@ androidx-compose-material3 = { group = "androidx.compose.material3", name = "mat
 koog-agents = { group = "ai.koog", name = "koog-agents", version.ref = "koog" }
 mediapipe-tasks-text = { group = "com.google.mediapipe", name = "tasks-text", version.ref = "mediapipeTasksText" }
 mediapipe-tasks-genai = { group = "com.google.mediapipe", name = "tasks-genai", version.ref = "mediapipeTasksGenai" }
+kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add a WorkManager-powered Gemma model download manager that exposes progress and result updates via Flow
- implement a CoroutineWorker to stream download progress, handle cancellation, and write the model file safely
- include WorkManager and coroutine Android dependencies in the build configuration

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: missing JDK 11 toolchain in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d6017f64832283e35820dc46746e