### PR TITLE
Add cycling toolbox (Day 2): RideContext, tool definitions, and executor

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
     // Note: LiteRT-LM is only used in :app module (Android implementation)
     // :agent module is pure Kotlin/JVM and uses interfaces only
     testImplementation(kotlin("test"))
+    testImplementation(libs.kotlinx.coroutines.test)
 }

--- a/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolDefinitions.kt
+++ b/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolDefinitions.kt
@@ -1,0 +1,157 @@
+package com.monday8am.edgelab.agent.cycling
+
+import com.monday8am.edgelab.data.testing.FunctionSpec
+import com.monday8am.edgelab.data.testing.ToolSpecification
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+/** OpenAPI tool schemas for the 6 cycling copilot tools. */
+object CyclingToolDefinitions {
+
+    const val GET_RIDE_STATUS = "get_ride_status"
+    const val GET_SEGMENT_AHEAD = "get_segment_ahead"
+    const val GET_WEATHER_FORECAST = "get_weather_forecast"
+    const val GET_ROUTE_ALTERNATIVES = "get_route_alternatives"
+    const val FIND_NEARBY_POI = "find_nearby_poi"
+    const val GET_RIDER_PROFILE = "get_rider_profile"
+
+    val ALL: List<ToolSpecification> =
+        listOf(
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = GET_RIDE_STATUS,
+                        description =
+                            "Returns current ride metrics: speed in km/h, distance covered in km," +
+                                " elapsed time in ms, and power in watts if available.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put("properties", buildJsonObject {})
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = GET_SEGMENT_AHEAD,
+                        description =
+                            "Returns the current and upcoming terrain segments (gravel sectors" +
+                                " and named sectors) relative to the rider's current position.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put("properties", buildJsonObject {})
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = GET_WEATHER_FORECAST,
+                        description =
+                            "Returns the weather forecast for current and upcoming hours," +
+                                " including temperature, wind, precipitation, and conditions.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put(
+                                    "properties",
+                                    buildJsonObject {
+                                        put(
+                                            "hours_ahead",
+                                            buildJsonObject {
+                                                put("type", "integer")
+                                                put(
+                                                    "description",
+                                                    "Number of upcoming hours to include (1-8). Defaults to 3.",
+                                                )
+                                            },
+                                        )
+                                    },
+                                )
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = GET_ROUTE_ALTERNATIVES,
+                        description =
+                            "Returns information about upcoming challenging road surfaces and" +
+                                " whether paved alternatives exist.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put("properties", buildJsonObject {})
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = FIND_NEARBY_POI,
+                        description =
+                            "Finds cafes, water sources, bike shops, and shelters near the" +
+                                " rider's current position.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put(
+                                    "properties",
+                                    buildJsonObject {
+                                        put(
+                                            "category",
+                                            buildJsonObject {
+                                                put("type", "string")
+                                                put(
+                                                    "enum",
+                                                    buildJsonArray {
+                                                        add(JsonPrimitive("cafe"))
+                                                        add(JsonPrimitive("water"))
+                                                        add(JsonPrimitive("bike_shop"))
+                                                        add(JsonPrimitive("shelter"))
+                                                    },
+                                                )
+                                                put("description", "Type of POI to search for.")
+                                            },
+                                        )
+                                        put(
+                                            "radius_km",
+                                            buildJsonObject {
+                                                put("type", "number")
+                                                put(
+                                                    "description",
+                                                    "Search radius in km. Defaults to 5.",
+                                                )
+                                            },
+                                        )
+                                    },
+                                )
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+            ToolSpecification(
+                function =
+                    FunctionSpec(
+                        name = GET_RIDER_PROFILE,
+                        description =
+                            "Returns the rider's baseline metrics: FTP, weight, and training" +
+                                " zones for pacing guidance.",
+                        parameters =
+                            buildJsonObject {
+                                put("type", "object")
+                                put("properties", buildJsonObject {})
+                                put("required", buildJsonArray {})
+                            },
+                    )
+            ),
+        )
+}

--- a/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutor.kt
+++ b/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutor.kt
@@ -1,0 +1,304 @@
+package com.monday8am.edgelab.agent.cycling
+
+import co.touchlab.kermit.Logger
+import com.monday8am.edgelab.data.route.RouteRepository
+import com.monday8am.edgelab.data.route.SegmentRepository
+import com.monday8am.edgelab.data.route.SegmentsData
+import com.monday8am.edgelab.data.route.WeatherData
+import com.monday8am.edgelab.data.route.WeatherRepository
+import com.monday8am.edgelab.data.testing.ToolSpecification
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.floatOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/**
+ * Executes the 6 cycling copilot tools against pre-loaded route, segment, and weather data.
+ *
+ * Call [initialize] once before a ride session to pre-load data. Then call [execute] for each tool
+ * invocation during the ride.
+ */
+class CyclingToolExecutor(
+    private val segmentRepository: SegmentRepository,
+    private val weatherRepository: WeatherRepository,
+    private val routeRepository: RouteRepository,
+) {
+
+    private val logger = Logger.withTag("CyclingToolExecutor")
+
+    private var cachedSegments: SegmentsData? = null
+    private var cachedWeather: WeatherData? = null
+    private var cachedTotalDistanceKm: Float = 0f
+
+    val toolDefinitions: List<ToolSpecification>
+        get() = CyclingToolDefinitions.ALL
+
+    /** Pre-loads route, segment, and weather data for [routeId]. Call once per ride session. */
+    suspend fun initialize(routeId: String) {
+        cachedSegments = segmentRepository.getSegments(routeId).getOrNull()
+        cachedWeather = weatherRepository.getWeather(routeId).getOrNull()
+        cachedTotalDistanceKm = routeRepository.getRoute(routeId).getOrNull()?.distanceKm ?: 0f
+        logger.i {
+            "Initialized: route=$routeId segments=${cachedSegments != null}" +
+                " weather=${cachedWeather != null} distanceKm=$cachedTotalDistanceKm"
+        }
+    }
+
+    /**
+     * Executes a tool by name and returns a JSON string result.
+     *
+     * @param toolName One of the constants in [CyclingToolDefinitions]
+     * @param paramsJson JSON object string with tool parameters (may be `"{}"`)
+     * @param rideContext Current rider state snapshot
+     */
+    fun execute(toolName: String, paramsJson: String, rideContext: RideContext): String {
+        val params =
+            try {
+                Json.parseToJsonElement(paramsJson).jsonObject
+            } catch (e: Exception) {
+                JsonObject(emptyMap())
+            }
+        return when (toolName) {
+            CyclingToolDefinitions.GET_RIDE_STATUS -> getRideStatus(rideContext)
+            CyclingToolDefinitions.GET_SEGMENT_AHEAD -> getSegmentAhead(rideContext)
+            CyclingToolDefinitions.GET_WEATHER_FORECAST -> getWeatherForecast(params, rideContext)
+            CyclingToolDefinitions.GET_ROUTE_ALTERNATIVES -> getRouteAlternatives(rideContext)
+            CyclingToolDefinitions.FIND_NEARBY_POI -> findNearbyPoi(params, rideContext)
+            CyclingToolDefinitions.GET_RIDER_PROFILE -> getRiderProfile()
+            else -> buildJsonObject { put("error", "Unknown tool: $toolName") }.toString()
+        }
+    }
+
+    private fun getRideStatus(ctx: RideContext): String =
+        buildJsonObject {
+                put("speed_kmh", ctx.speedKmh)
+                put("distance_km", ctx.distanceTravelledKm)
+                put("elapsed_ms", ctx.elapsedMs)
+                put("total_distance_km", ctx.totalDistanceKm)
+                if (ctx.totalDistanceKm > 0) {
+                    put("progress_pct", ctx.distanceTravelledKm / ctx.totalDistanceKm * 100f)
+                }
+                ctx.power?.let { put("power_watts", it) }
+            }
+            .toString()
+
+    private fun getSegmentAhead(ctx: RideContext): String {
+        val segments =
+            cachedSegments
+                ?: return buildJsonObject { put("error", "Segment data not loaded") }.toString()
+
+        val currentNamed =
+            segments.namedSectors.firstOrNull { ctx.routePointIndex in it.fromIndex..it.toIndex }
+        val currentGravel =
+            segments.gravelSectors.firstOrNull { ctx.routePointIndex in it.fromIndex..it.toIndex }
+        val nextNamed =
+            segments.namedSectors
+                .filter { it.fromIndex > ctx.routePointIndex }
+                .minByOrNull { it.fromIndex }
+        val nextGravel =
+            segments.gravelSectors
+                .filter { it.fromIndex > ctx.routePointIndex }
+                .minByOrNull { it.fromIndex }
+
+        return buildJsonObject {
+                currentNamed?.let {
+                    put(
+                        "current_named_sector",
+                        buildJsonObject {
+                            put("name", it.name)
+                            put("surface", it.surface)
+                            put("distance_m", it.distanceM)
+                            put("elevation_up_m", it.elevationUpM)
+                        },
+                    )
+                }
+                currentGravel?.let {
+                    put(
+                        "current_gravel_sector",
+                        buildJsonObject {
+                            put("surface", it.surface)
+                            put("distance_m", it.distanceM)
+                            put("elevation_up_m", it.elevationUpM)
+                        },
+                    )
+                }
+                nextNamed?.let {
+                    put(
+                        "next_named_sector",
+                        buildJsonObject {
+                            put("name", it.name)
+                            put("surface", it.surface)
+                            put("distance_m", it.distanceM)
+                            put("elevation_up_m", it.elevationUpM)
+                            put("km_from_start", it.kmFromStart)
+                            put("km_ahead", it.kmFromStart - ctx.distanceTravelledKm)
+                        },
+                    )
+                }
+                nextGravel?.let {
+                    put(
+                        "next_gravel_sector",
+                        buildJsonObject {
+                            put("surface", it.surface)
+                            put("distance_m", it.distanceM)
+                            put("elevation_up_m", it.elevationUpM)
+                            put("km_from_start", it.kmFromStart)
+                            put("km_ahead", it.kmFromStart - ctx.distanceTravelledKm)
+                        },
+                    )
+                }
+                if (
+                    currentNamed == null &&
+                        currentGravel == null &&
+                        nextNamed == null &&
+                        nextGravel == null
+                ) {
+                    put("message", "No more segments ahead")
+                }
+            }
+            .toString()
+    }
+
+    private fun getWeatherForecast(params: JsonObject, ctx: RideContext): String {
+        val weather =
+            cachedWeather
+                ?: return buildJsonObject { put("error", "Weather data not loaded") }.toString()
+
+        val hoursAhead = params["hours_ahead"]?.jsonPrimitive?.intOrNull ?: 3
+        val startHour = (ctx.elapsedMs / 3_600_000L).toInt().coerceIn(0, 23)
+        val hours = weather.hourly.filter { it.hour >= startHour }.take(hoursAhead + 1)
+
+        return buildJsonObject {
+                put("location", weather.location)
+                put("summary", weather.summary)
+                put(
+                    "hourly",
+                    buildJsonArray {
+                        hours.forEach { h ->
+                            add(
+                                buildJsonObject {
+                                    put("hour", h.hour)
+                                    put("temp_c", h.tempC)
+                                    put("feels_like_c", h.feelsLikeC)
+                                    put("wind_kph", h.windKph)
+                                    put("wind_dir", h.windDir)
+                                    put("humidity_pct", h.humidityPct)
+                                    put("condition", h.condition)
+                                    put("precip_mm", h.precipMm)
+                                    put("uv_index", h.uvIndex)
+                                }
+                            )
+                        }
+                    },
+                )
+            }
+            .toString()
+    }
+
+    private fun getRouteAlternatives(ctx: RideContext): String {
+        val segments =
+            cachedSegments
+                ?: return buildJsonObject { put("error", "Segment data not loaded") }.toString()
+
+        val upcoming = segments.gravelSectors.filter { it.fromIndex > ctx.routePointIndex }.take(3)
+
+        return buildJsonObject {
+                put(
+                    "note",
+                    "Official Strade Bianche route. Gravel sectors are integral to the race course.",
+                )
+                put(
+                    "upcoming_challenging_sectors",
+                    buildJsonArray {
+                        upcoming.forEach { g ->
+                            add(
+                                buildJsonObject {
+                                    put("surface", g.surface)
+                                    put("distance_m", g.distanceM)
+                                    put("elevation_up_m", g.elevationUpM)
+                                    put("km_from_start", g.kmFromStart)
+                                    put("km_ahead", g.kmFromStart - ctx.distanceTravelledKm)
+                                    put("has_paved_alternative", false)
+                                }
+                            )
+                        }
+                    },
+                )
+            }
+            .toString()
+    }
+
+    private fun findNearbyPoi(params: JsonObject, ctx: RideContext): String {
+        val category = params["category"]?.jsonPrimitive?.contentOrNull
+        val radiusKm = params["radius_km"]?.jsonPrimitive?.floatOrNull ?: 5f
+
+        val filtered =
+            STRADE_BIANCHE_POIS.filter { poi ->
+                (category == null || poi.category == category) &&
+                    kotlin.math.abs(poi.kmFromStart - ctx.distanceTravelledKm) <= radiusKm
+            }
+
+        return buildJsonObject {
+                category?.let { put("category_filter", it) }
+                put("radius_km", radiusKm)
+                put(
+                    "pois",
+                    buildJsonArray {
+                        filtered.forEach { poi ->
+                            add(
+                                buildJsonObject {
+                                    put("name", poi.name)
+                                    put("category", poi.category)
+                                    put("km_from_start", poi.kmFromStart)
+                                    put("km_ahead", poi.kmFromStart - ctx.distanceTravelledKm)
+                                }
+                            )
+                        }
+                    },
+                )
+            }
+            .toString()
+    }
+
+    private fun getRiderProfile(): String =
+        buildJsonObject {
+                put("ftp_watts", 250)
+                put("weight_kg", 70)
+                put(
+                    "zones",
+                    buildJsonObject {
+                        put("z1_recovery", "< 140W")
+                        put("z2_endurance", "140-188W")
+                        put("z3_tempo", "188-213W")
+                        put("z4_threshold", "213-250W")
+                        put("z5_vo2max", "> 250W")
+                    },
+                )
+                put("note", "Default profile. Customize in rider settings.")
+            }
+            .toString()
+
+    private data class PoiInfo(val name: String, val category: String, val kmFromStart: Float)
+
+    private companion object {
+        // Hardcoded Strade Bianche POIs — replaced by PoiRepository in Day 7
+        val STRADE_BIANCHE_POIS =
+            listOf(
+                PoiInfo("Fonte di Siena", "water", 0f),
+                PoiInfo("Cicli Pieri Siena", "bike_shop", 4f),
+                PoiInfo("Bar Il Casato", "cafe", 12f),
+                PoiInfo("Rifugio Crete Senesi", "shelter", 25f),
+                PoiInfo("Osteria del Grillo", "cafe", 34f),
+                PoiInfo("Acqua Pubblica Buonconvento", "water", 48f),
+                PoiInfo("Bar Sport Montalcino", "cafe", 82f),
+                PoiInfo("Fontana del Casato", "water", 130f),
+                PoiInfo("Ciclofficina Siena", "bike_shop", 160f),
+            )
+    }
+}

--- a/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutor.kt
+++ b/agent/src/main/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutor.kt
@@ -1,12 +1,12 @@
 package com.monday8am.edgelab.agent.cycling
 
 import co.touchlab.kermit.Logger
-import com.monday8am.edgelab.data.route.RouteRepository
 import com.monday8am.edgelab.data.route.SegmentRepository
 import com.monday8am.edgelab.data.route.SegmentsData
 import com.monday8am.edgelab.data.route.WeatherData
 import com.monday8am.edgelab.data.route.WeatherRepository
 import com.monday8am.edgelab.data.testing.ToolSpecification
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.buildJsonArray
@@ -27,26 +27,23 @@ import kotlinx.serialization.json.put
 class CyclingToolExecutor(
     private val segmentRepository: SegmentRepository,
     private val weatherRepository: WeatherRepository,
-    private val routeRepository: RouteRepository,
 ) {
 
     private val logger = Logger.withTag("CyclingToolExecutor")
 
     private var cachedSegments: SegmentsData? = null
     private var cachedWeather: WeatherData? = null
-    private var cachedTotalDistanceKm: Float = 0f
 
     val toolDefinitions: List<ToolSpecification>
         get() = CyclingToolDefinitions.ALL
 
-    /** Pre-loads route, segment, and weather data for [routeId]. Call once per ride session. */
+    /** Pre-loads segment and weather data for [routeId]. Call once per ride session. */
     suspend fun initialize(routeId: String) {
         cachedSegments = segmentRepository.getSegments(routeId).getOrNull()
         cachedWeather = weatherRepository.getWeather(routeId).getOrNull()
-        cachedTotalDistanceKm = routeRepository.getRoute(routeId).getOrNull()?.distanceKm ?: 0f
         logger.i {
             "Initialized: route=$routeId segments=${cachedSegments != null}" +
-                " weather=${cachedWeather != null} distanceKm=$cachedTotalDistanceKm"
+                " weather=${cachedWeather != null}"
         }
     }
 
@@ -61,7 +58,9 @@ class CyclingToolExecutor(
         val params =
             try {
                 Json.parseToJsonElement(paramsJson).jsonObject
-            } catch (e: Exception) {
+            } catch (e: SerializationException) {
+                JsonObject(emptyMap())
+            } catch (e: IllegalArgumentException) {
                 JsonObject(emptyMap())
             }
         return when (toolName) {
@@ -171,8 +170,8 @@ class CyclingToolExecutor(
                 ?: return buildJsonObject { put("error", "Weather data not loaded") }.toString()
 
         val hoursAhead = params["hours_ahead"]?.jsonPrimitive?.intOrNull ?: 3
-        val startHour = (ctx.elapsedMs / 3_600_000L).toInt().coerceIn(0, 23)
-        val hours = weather.hourly.filter { it.hour >= startHour }.take(hoursAhead + 1)
+        val currentHour = (ctx.rideStartHour + ctx.elapsedMs / 3_600_000L).toInt().coerceIn(0, 23)
+        val hours = weather.hourly.filter { it.hour >= currentHour }.take(hoursAhead + 1)
 
         return buildJsonObject {
                 put("location", weather.location)

--- a/agent/src/main/java/com/monday8am/edgelab/agent/cycling/RideContext.kt
+++ b/agent/src/main/java/com/monday8am/edgelab/agent/cycling/RideContext.kt
@@ -8,4 +8,6 @@ data class RideContext(
     val power: Int?,
     val elapsedMs: Long = 0L,
     val totalDistanceKm: Float,
+    /** Actual clock hour when the ride started (0-23), used for weather indexing. */
+    val rideStartHour: Int = 8,
 )

--- a/agent/src/main/java/com/monday8am/edgelab/agent/cycling/RideContext.kt
+++ b/agent/src/main/java/com/monday8am/edgelab/agent/cycling/RideContext.kt
@@ -1,0 +1,11 @@
+package com.monday8am.edgelab.agent.cycling
+
+/** Current snapshot of the rider's state, passed to each tool at execution time. */
+data class RideContext(
+    val routePointIndex: Int,
+    val distanceTravelledKm: Float,
+    val speedKmh: Float,
+    val power: Int?,
+    val elapsedMs: Long = 0L,
+    val totalDistanceKm: Float,
+)

--- a/agent/src/test/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutorTest.kt
+++ b/agent/src/test/java/com/monday8am/edgelab/agent/cycling/CyclingToolExecutorTest.kt
@@ -1,0 +1,361 @@
+package com.monday8am.edgelab.agent.cycling
+
+import com.monday8am.edgelab.data.route.GravelSector
+import com.monday8am.edgelab.data.route.HourlyWeather
+import com.monday8am.edgelab.data.route.RouteCoordinate
+import com.monday8am.edgelab.data.route.RouteData
+import com.monday8am.edgelab.data.route.RouteRepository
+import com.monday8am.edgelab.data.route.SegmentData
+import com.monday8am.edgelab.data.route.SegmentRepository
+import com.monday8am.edgelab.data.route.SegmentsData
+import com.monday8am.edgelab.data.route.WeatherData
+import com.monday8am.edgelab.data.route.WeatherRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+
+class CyclingToolExecutorTest {
+
+    // region Fakes
+
+    private class FakeSegmentRepository(private val data: SegmentsData) : SegmentRepository {
+        var getSegmentsCallCount = 0
+
+        override suspend fun getSegments(routeId: String): Result<SegmentsData> {
+            getSegmentsCallCount++
+            return Result.success(data)
+        }
+
+        override fun segmentsFlow(routeId: String): Flow<SegmentsData> = flowOf(data)
+    }
+
+    private class FakeWeatherRepository(private val data: WeatherData) : WeatherRepository {
+        override suspend fun getWeather(routeId: String): Result<WeatherData> = Result.success(data)
+
+        override fun weatherFlow(routeId: String): Flow<WeatherData> = flowOf(data)
+    }
+
+    private class FakeRouteRepository(private val data: RouteData) : RouteRepository {
+        override suspend fun getRoute(routeId: String): Result<RouteData> = Result.success(data)
+
+        override fun routeFlow(routeId: String): Flow<RouteData> = flowOf(data)
+    }
+
+    // endregion
+
+    // region Test fixtures
+
+    private val testSegments =
+        SegmentsData(
+            routeId = "test-route",
+            namedSectors =
+                listOf(
+                    SegmentData(
+                        id = "s1",
+                        name = "Monte Sante Marie",
+                        category = "strade_bianche",
+                        fromIndex = 100,
+                        toIndex = 200,
+                        startLat = 43.3,
+                        startLng = 11.2,
+                        distanceM = 8500,
+                        elevationUpM = 290,
+                        surface = "unpaved",
+                        kmFromStart = 10.0f,
+                    ),
+                    SegmentData(
+                        id = "s2",
+                        name = "Bagnaia Gravel Sector",
+                        category = "strade_bianche",
+                        fromIndex = 400,
+                        toIndex = 520,
+                        startLat = 43.4,
+                        startLng = 11.3,
+                        distanceM = 7800,
+                        elevationUpM = 220,
+                        surface = "gravel",
+                        kmFromStart = 30.0f,
+                    ),
+                ),
+            gravelSectors =
+                listOf(
+                    GravelSector(
+                        fromIndex = 90,
+                        toIndex = 210,
+                        startLat = 43.3,
+                        startLng = 11.2,
+                        distanceM = 9000,
+                        elevationUpM = 300,
+                        surface = "gravel",
+                        kmFromStart = 9.5f,
+                    ),
+                    GravelSector(
+                        fromIndex = 380,
+                        toIndex = 530,
+                        startLat = 43.4,
+                        startLng = 11.3,
+                        distanceM = 8200,
+                        elevationUpM = 250,
+                        surface = "gravel",
+                        kmFromStart = 29.0f,
+                    ),
+                ),
+        )
+
+    private val testWeather =
+        WeatherData(
+            routeId = "test-route",
+            location = "Siena, Italy",
+            date = "2026-03-01",
+            timezone = "Europe/Rome",
+            summary = "Partly cloudy with light winds",
+            hourly =
+                listOf(
+                    HourlyWeather(8, 12, 10, 15, "NW", 65, "Partly cloudy", 0f, 3),
+                    HourlyWeather(9, 14, 12, 18, "NW", 60, "Sunny", 0f, 4),
+                    HourlyWeather(10, 15, 13, 20, "N", 55, "Sunny", 0.2f, 5),
+                    HourlyWeather(11, 14, 12, 22, "N", 58, "Cloudy", 0.5f, 4),
+                ),
+        )
+
+    private val testRoute =
+        RouteData(
+            routeId = "test-route",
+            name = "Test Route",
+            distanceKm = 184f,
+            coordinates = listOf(RouteCoordinate(43.3, 11.2, 300.0, 0L)),
+        )
+
+    private fun createExecutor() =
+        CyclingToolExecutor(
+            segmentRepository = FakeSegmentRepository(testSegments),
+            weatherRepository = FakeWeatherRepository(testWeather),
+            routeRepository = FakeRouteRepository(testRoute),
+        )
+
+    private val defaultContext =
+        RideContext(
+            routePointIndex = 50,
+            distanceTravelledKm = 5.0f,
+            speedKmh = 28.5f,
+            power = 215,
+            elapsedMs = 720_000L,
+            totalDistanceKm = 184f,
+        )
+
+    // endregion
+
+    // region Initialization Tests
+
+    @Test
+    fun `initialize loads data from all repositories`() = runBlocking {
+        val fakeSegments = FakeSegmentRepository(testSegments)
+        val executor =
+            CyclingToolExecutor(
+                segmentRepository = fakeSegments,
+                weatherRepository = FakeWeatherRepository(testWeather),
+                routeRepository = FakeRouteRepository(testRoute),
+            )
+        executor.initialize("test-route")
+        assertEquals(1, fakeSegments.getSegmentsCallCount)
+    }
+
+    @Test
+    fun `toolDefinitions returns all 6 tools`() {
+        val executor = createExecutor()
+        assertEquals(6, executor.toolDefinitions.size)
+        val names = executor.toolDefinitions.map { it.function.name }
+        assertTrue(CyclingToolDefinitions.GET_RIDE_STATUS in names)
+        assertTrue(CyclingToolDefinitions.GET_SEGMENT_AHEAD in names)
+        assertTrue(CyclingToolDefinitions.GET_WEATHER_FORECAST in names)
+        assertTrue(CyclingToolDefinitions.GET_ROUTE_ALTERNATIVES in names)
+        assertTrue(CyclingToolDefinitions.FIND_NEARBY_POI in names)
+        assertTrue(CyclingToolDefinitions.GET_RIDER_PROFILE in names)
+    }
+
+    // endregion
+
+    // region get_ride_status Tests
+
+    @Test
+    fun `get_ride_status returns current speed and distance`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result = executor.execute(CyclingToolDefinitions.GET_RIDE_STATUS, "{}", defaultContext)
+        assertTrue("speed_kmh" in result)
+        assertTrue("distance_km" in result)
+        assertTrue("elapsed_ms" in result)
+    }
+
+    @Test
+    fun `get_ride_status includes power when available`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result = executor.execute(CyclingToolDefinitions.GET_RIDE_STATUS, "{}", defaultContext)
+        assertTrue("power_watts" in result)
+        assertTrue("215" in result)
+    }
+
+    @Test
+    fun `get_ride_status omits power when null`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val ctx = defaultContext.copy(power = null)
+        val result = executor.execute(CyclingToolDefinitions.GET_RIDE_STATUS, "{}", ctx)
+        assertFalse("power_watts" in result)
+    }
+
+    // endregion
+
+    // region get_segment_ahead Tests
+
+    @Test
+    fun `get_segment_ahead returns next named sector ahead`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        // routePointIndex=50, before fromIndex=100 of "Monte Sante Marie"
+        val result =
+            executor.execute(CyclingToolDefinitions.GET_SEGMENT_AHEAD, "{}", defaultContext)
+        assertTrue("Monte Sante Marie" in result)
+        assertTrue("next_named_sector" in result)
+    }
+
+    @Test
+    fun `get_segment_ahead reports current sector when inside one`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val ctx = defaultContext.copy(routePointIndex = 150) // inside fromIndex=100..toIndex=200
+        val result = executor.execute(CyclingToolDefinitions.GET_SEGMENT_AHEAD, "{}", ctx)
+        assertTrue("current_named_sector" in result)
+        assertTrue("Monte Sante Marie" in result)
+    }
+
+    @Test
+    fun `get_segment_ahead returns no more segments at end of route`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val ctx = defaultContext.copy(routePointIndex = 9999)
+        val result = executor.execute(CyclingToolDefinitions.GET_SEGMENT_AHEAD, "{}", ctx)
+        assertTrue("No more segments ahead" in result)
+    }
+
+    @Test
+    fun `get_segment_ahead returns error when not initialized`() {
+        val executor = createExecutor()
+        // No initialize() call
+        val result =
+            executor.execute(CyclingToolDefinitions.GET_SEGMENT_AHEAD, "{}", defaultContext)
+        assertTrue("error" in result)
+    }
+
+    // endregion
+
+    // region get_weather_forecast Tests
+
+    @Test
+    fun `get_weather_forecast returns location and summary`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result =
+            executor.execute(CyclingToolDefinitions.GET_WEATHER_FORECAST, "{}", defaultContext)
+        assertTrue("Siena, Italy" in result)
+        assertTrue("Partly cloudy" in result)
+        assertTrue("hourly" in result)
+    }
+
+    @Test
+    fun `get_weather_forecast respects hours_ahead parameter`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result =
+            executor.execute(
+                CyclingToolDefinitions.GET_WEATHER_FORECAST,
+                """{"hours_ahead": 1}""",
+                defaultContext.copy(elapsedMs = 0L),
+            )
+        // With elapsedMs=0, startHour=0, and hours_ahead=1, we get hours[0..1] = 2 entries
+        // Just verify the response is valid and contains hourly data
+        assertTrue("hourly" in result)
+        assertTrue("temp_c" in result)
+    }
+
+    // endregion
+
+    // region get_route_alternatives Tests
+
+    @Test
+    fun `get_route_alternatives returns upcoming gravel sectors`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result =
+            executor.execute(CyclingToolDefinitions.GET_ROUTE_ALTERNATIVES, "{}", defaultContext)
+        assertTrue("upcoming_challenging_sectors" in result)
+        assertTrue("has_paved_alternative" in result)
+    }
+
+    // endregion
+
+    // region find_nearby_poi Tests
+
+    @Test
+    fun `find_nearby_poi returns pois within default radius`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        // distanceTravelledKm=5.0, radius=5 → should find Bar Il Casato at km 12 (7km away,
+        // outside)
+        // but Fonte di Siena at km 0 (5km away, within) and Cicli Pieri at km 4 (1km away)
+        val ctx = defaultContext.copy(distanceTravelledKm = 5.0f)
+        val result = executor.execute(CyclingToolDefinitions.FIND_NEARBY_POI, "{}", ctx)
+        assertTrue("pois" in result)
+        assertTrue("Fonte di Siena" in result)
+    }
+
+    @Test
+    fun `find_nearby_poi filters by category`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result =
+            executor.execute(
+                CyclingToolDefinitions.FIND_NEARBY_POI,
+                """{"category": "cafe", "radius_km": 100}""",
+                defaultContext,
+            )
+        assertTrue("cafe" in result)
+        assertFalse("bike_shop" in result)
+        assertFalse("water" in result)
+    }
+
+    // endregion
+
+    // region get_rider_profile Tests
+
+    @Test
+    fun `get_rider_profile returns ftp and zones`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result =
+            executor.execute(CyclingToolDefinitions.GET_RIDER_PROFILE, "{}", defaultContext)
+        assertTrue("ftp_watts" in result)
+        assertTrue("zones" in result)
+        assertTrue("250" in result)
+    }
+
+    // endregion
+
+    // region Unknown Tool Tests
+
+    @Test
+    fun `execute returns error for unknown tool`() = runBlocking {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        val result = executor.execute("unknown_tool", "{}", defaultContext)
+        assertTrue("error" in result)
+        assertTrue("unknown_tool" in result)
+    }
+
+    // endregion
+}

--- a/agent/src/test/kotlin/com/monday8am/edgelab/agent/cycling/CyclingToolExecutorTest.kt
+++ b/agent/src/test/kotlin/com/monday8am/edgelab/agent/cycling/CyclingToolExecutorTest.kt
@@ -2,9 +2,6 @@ package com.monday8am.edgelab.agent.cycling
 
 import com.monday8am.edgelab.data.route.GravelSector
 import com.monday8am.edgelab.data.route.HourlyWeather
-import com.monday8am.edgelab.data.route.RouteCoordinate
-import com.monday8am.edgelab.data.route.RouteData
-import com.monday8am.edgelab.data.route.RouteRepository
 import com.monday8am.edgelab.data.route.SegmentData
 import com.monday8am.edgelab.data.route.SegmentRepository
 import com.monday8am.edgelab.data.route.SegmentsData
@@ -14,10 +11,12 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class CyclingToolExecutorTest {
 
     // region Fakes
@@ -37,12 +36,6 @@ class CyclingToolExecutorTest {
         override suspend fun getWeather(routeId: String): Result<WeatherData> = Result.success(data)
 
         override fun weatherFlow(routeId: String): Flow<WeatherData> = flowOf(data)
-    }
-
-    private class FakeRouteRepository(private val data: RouteData) : RouteRepository {
-        override suspend fun getRoute(routeId: String): Result<RouteData> = Result.success(data)
-
-        override fun routeFlow(routeId: String): Flow<RouteData> = flowOf(data)
     }
 
     // endregion
@@ -122,19 +115,10 @@ class CyclingToolExecutorTest {
                 ),
         )
 
-    private val testRoute =
-        RouteData(
-            routeId = "test-route",
-            name = "Test Route",
-            distanceKm = 184f,
-            coordinates = listOf(RouteCoordinate(43.3, 11.2, 300.0, 0L)),
-        )
-
     private fun createExecutor() =
         CyclingToolExecutor(
             segmentRepository = FakeSegmentRepository(testSegments),
             weatherRepository = FakeWeatherRepository(testWeather),
-            routeRepository = FakeRouteRepository(testRoute),
         )
 
     private val defaultContext =
@@ -145,6 +129,7 @@ class CyclingToolExecutorTest {
             power = 215,
             elapsedMs = 720_000L,
             totalDistanceKm = 184f,
+            rideStartHour = 8,
         )
 
     // endregion
@@ -152,13 +137,12 @@ class CyclingToolExecutorTest {
     // region Initialization Tests
 
     @Test
-    fun `initialize loads data from all repositories`() = runBlocking {
+    fun `initialize loads data from all repositories`() = runTest {
         val fakeSegments = FakeSegmentRepository(testSegments)
         val executor =
             CyclingToolExecutor(
                 segmentRepository = fakeSegments,
                 weatherRepository = FakeWeatherRepository(testWeather),
-                routeRepository = FakeRouteRepository(testRoute),
             )
         executor.initialize("test-route")
         assertEquals(1, fakeSegments.getSegmentsCallCount)
@@ -182,7 +166,7 @@ class CyclingToolExecutorTest {
     // region get_ride_status Tests
 
     @Test
-    fun `get_ride_status returns current speed and distance`() = runBlocking {
+    fun `get_ride_status returns current speed and distance`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result = executor.execute(CyclingToolDefinitions.GET_RIDE_STATUS, "{}", defaultContext)
@@ -192,7 +176,7 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `get_ride_status includes power when available`() = runBlocking {
+    fun `get_ride_status includes power when available`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result = executor.execute(CyclingToolDefinitions.GET_RIDE_STATUS, "{}", defaultContext)
@@ -201,7 +185,7 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `get_ride_status omits power when null`() = runBlocking {
+    fun `get_ride_status omits power when null`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val ctx = defaultContext.copy(power = null)
@@ -214,7 +198,7 @@ class CyclingToolExecutorTest {
     // region get_segment_ahead Tests
 
     @Test
-    fun `get_segment_ahead returns next named sector ahead`() = runBlocking {
+    fun `get_segment_ahead returns next named sector ahead`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         // routePointIndex=50, before fromIndex=100 of "Monte Sante Marie"
@@ -225,7 +209,7 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `get_segment_ahead reports current sector when inside one`() = runBlocking {
+    fun `get_segment_ahead reports current sector when inside one`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val ctx = defaultContext.copy(routePointIndex = 150) // inside fromIndex=100..toIndex=200
@@ -235,7 +219,7 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `get_segment_ahead returns no more segments at end of route`() = runBlocking {
+    fun `get_segment_ahead returns no more segments at end of route`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val ctx = defaultContext.copy(routePointIndex = 9999)
@@ -257,7 +241,7 @@ class CyclingToolExecutorTest {
     // region get_weather_forecast Tests
 
     @Test
-    fun `get_weather_forecast returns location and summary`() = runBlocking {
+    fun `get_weather_forecast returns location and summary`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result =
@@ -268,17 +252,28 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `get_weather_forecast respects hours_ahead parameter`() = runBlocking {
+    fun `get_weather_forecast filters by current clock hour`() = runTest {
+        val executor = createExecutor()
+        executor.initialize("test-route")
+        // rideStartHour=8, elapsedMs=3_600_000 (1 hour) → currentHour=9
+        // Hourly data has hours 8,9,10,11 → filter hour >= 9 → returns hours 9,10,11
+        val ctx = defaultContext.copy(rideStartHour = 8, elapsedMs = 3_600_000L)
+        val result = executor.execute(CyclingToolDefinitions.GET_WEATHER_FORECAST, "{}", ctx)
+        assertTrue("hourly" in result)
+        // Hour 8 should be excluded (already past)
+        assertFalse("\"hour\":8" in result.replace(" ", ""))
+    }
+
+    @Test
+    fun `get_weather_forecast respects hours_ahead parameter`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result =
             executor.execute(
                 CyclingToolDefinitions.GET_WEATHER_FORECAST,
                 """{"hours_ahead": 1}""",
-                defaultContext.copy(elapsedMs = 0L),
+                defaultContext.copy(rideStartHour = 8, elapsedMs = 0L),
             )
-        // With elapsedMs=0, startHour=0, and hours_ahead=1, we get hours[0..1] = 2 entries
-        // Just verify the response is valid and contains hourly data
         assertTrue("hourly" in result)
         assertTrue("temp_c" in result)
     }
@@ -288,7 +283,7 @@ class CyclingToolExecutorTest {
     // region get_route_alternatives Tests
 
     @Test
-    fun `get_route_alternatives returns upcoming gravel sectors`() = runBlocking {
+    fun `get_route_alternatives returns upcoming gravel sectors`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result =
@@ -302,12 +297,11 @@ class CyclingToolExecutorTest {
     // region find_nearby_poi Tests
 
     @Test
-    fun `find_nearby_poi returns pois within default radius`() = runBlocking {
+    fun `find_nearby_poi returns pois within default radius`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
-        // distanceTravelledKm=5.0, radius=5 → should find Bar Il Casato at km 12 (7km away,
-        // outside)
-        // but Fonte di Siena at km 0 (5km away, within) and Cicli Pieri at km 4 (1km away)
+        // distanceTravelledKm=5.0, radius=5 → Fonte di Siena at km 0 (5km away, at boundary)
+        // and Cicli Pieri at km 4 (1km away, within)
         val ctx = defaultContext.copy(distanceTravelledKm = 5.0f)
         val result = executor.execute(CyclingToolDefinitions.FIND_NEARBY_POI, "{}", ctx)
         assertTrue("pois" in result)
@@ -315,7 +309,7 @@ class CyclingToolExecutorTest {
     }
 
     @Test
-    fun `find_nearby_poi filters by category`() = runBlocking {
+    fun `find_nearby_poi filters by category`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result =
@@ -334,7 +328,7 @@ class CyclingToolExecutorTest {
     // region get_rider_profile Tests
 
     @Test
-    fun `get_rider_profile returns ftp and zones`() = runBlocking {
+    fun `get_rider_profile returns ftp and zones`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result =
@@ -349,7 +343,7 @@ class CyclingToolExecutorTest {
     // region Unknown Tool Tests
 
     @Test
-    fun `execute returns error for unknown tool`() = runBlocking {
+    fun `execute returns error for unknown tool`() = runTest {
         val executor = createExecutor()
         executor.initialize("test-route")
         val result = executor.execute("unknown_tool", "{}", defaultContext)


### PR DESCRIPTION
## Summary

- Builds the copilot's toolbox: 6 cycling tools the AI can call to answer rider questions
- Pre-loads segment, weather, and route data once at ride start; executes synchronously during inference
- Clean separation between tool schemas (definitions) and execution logic (executor)

## Changes

- **`RideContext`** — data class capturing the rider's current state snapshot (speed, distance, power, elapsed time), passed to every tool at execution time
- **`CyclingToolDefinitions`** — OpenAPI schemas for 6 tools: `get_ride_status`, `get_segment_ahead`, `get_weather_forecast`, `get_route_alternatives`, `find_nearby_poi`, `get_rider_profile`
- **`CyclingToolExecutor`** — pre-loads data via `initialize(routeId)`, then `execute(toolName, paramsJson, rideContext)` dispatches to the right data source and returns a JSON string
- **`CyclingToolExecutorTest`** — 16 unit tests with fake repositories covering all 6 tools + error paths + uninitialized state

## Technical Details

- Executor lives in `:agent` (pure Kotlin/JVM) alongside `NotificationAgent` and `OpenApiToolHandler`
- Data flows: `initialize()` calls segment/weather/route repositories once; tools read from cached data during execution (no blocking I/O during inference)
- `find_nearby_poi` uses hardcoded Strade Bianche POIs — will be replaced by `PoiRepository` in Day 7
- `get_rider_profile` returns hardcoded defaults — will become configurable in Day 9
- Day 3 (`CopilotAgent`) will wrap the executor in `OpenApiTool` instances and wire to LiteRT-LM

🤖 Generated with [Claude Code](https://claude.com/claude-code)