### PR TITLE
Remove CPU_ONLY backend and add slash commands

### DIFF
--- a/.opencode/commands/commit-pr.md
+++ b/.opencode/commands/commit-pr.md
@@ -1,0 +1,151 @@
+---
+description: Commit changes, push, and create a GitHub PR. Lightweight alternative to /commit-pr-greptile — no Greptile review loop.
+agent: build
+subtask: true
+---
+
+# Commit, Push, and Create PR
+
+You are an autonomous coding agent that commits code, pushes it, and creates a GitHub PR.
+
+## Goal
+
+1. Run pre-flight checks
+2. Commit current changes
+3. Push to remote
+4. Create or reuse a GitHub PR
+5. Print PR URL and exit
+
+---
+
+## Step 0 — Pre-flight Checks
+
+Run these checks first:
+
+```bash
+# Confirm we are in a git repo
+git rev-parse --show-toplevel
+
+# Check current branch
+git branch --show-current
+
+# Confirm gh CLI is authenticated
+gh auth status
+
+# Check for staged or unstaged changes
+git status --short
+```
+
+If there are no changes to commit:
+> "No changes detected to commit. Exiting."
+
+If not on a feature branch (e.g., on `main` or `master`):
+> "You appear to be on the main branch. Please switch to a feature branch first."
+
+---
+
+## Step 1 — Format, Stage, and Commit
+
+1. **Run formatting** if the project uses ktfmt:
+   ```bash
+   ./gradlew ktfmtFormat
+   ```
+
+2. **Stage all changes**:
+   ```bash
+   git add -A
+   ```
+
+3. **Generate commit message**:
+   - Review changed files: `git status --short`
+   - Review diff stats: `git diff --staged --stat`
+   - Create a descriptive commit message following this format:
+     ```
+     <Short summary (imperative mood)>
+
+     <Detailed bullet points of changes>
+     ```
+
+4. **Commit**:
+   ```bash
+   git commit -m "<commit message>"
+   ```
+
+   If commit fails due to pre-commit hooks:
+   - If it's ktfmt/formatting: run `./gradlew ktfmtFormat`, stage changes, and retry commit
+   - If it's other linting: fix the issues, stage, and retry
+   - If it fails twice: inform user and stop
+
+---
+
+## Step 2 — Push
+
+```bash
+git push -u origin <current-branch>
+```
+
+If push is rejected due to remote having newer commits:
+- Do NOT force-push
+- Ask user to resolve the merge conflict first
+
+---
+
+## Step 3 — Create or Reuse Pull Request
+
+1. **Check if an open PR already exists**:
+   ```bash
+   gh pr view --json number,url,title,state 2>/dev/null
+   ```
+
+   - If the command fails (no PR) → proceed to create one
+   - If `state` is `"OPEN"` → reuse existing PR, skip creation
+   - If `state` is `"CLOSED"` or `"MERGED"` → create a new PR
+
+2. **If no open PR exists**, create one:
+   - Extract info from commits: `git log origin/main..HEAD --oneline`
+   - Generate PR title (short, imperative, <70 chars)
+   - Generate PR body with:
+     - Summary section
+     - Changes section (bullet points)
+     - Technical details if applicable
+
+   ```bash
+   gh pr create --title "<title>" --body "<generated body>"
+   ```
+
+3. **Print result**:
+   ```
+   ✅ PR ready
+   #<N> — <title>
+   URL: <pr-url>
+   Branch: <branch-name>
+   ```
+
+---
+
+## Error Handling
+
+| Situation | Action |
+|-----------|--------|
+| No changes to commit | Exit early with message |
+| On main/master branch | Ask user to switch to a feature branch |
+| Push rejected by hooks | Fix issues, retry once, then ask user |
+| PR creation fails | Show error, ask user to resolve |
+| Existing PR is closed/merged | Ignore it, create a new PR |
+| Remote has newer commits | Do not force-push, ask user to pull/resolve |
+
+---
+
+## Final Summary
+
+After completing, show:
+
+```
+## PR Created
+
+**PR**: #<N> — <title>
+**URL**: <pr-url>
+**Branch**: <branch-name>
+**Commits**:
+- <sha> — <commit message>
+```

--- a/.opencode/commands/commit-pr.md
+++ b/.opencode/commands/commit-pr.md
@@ -102,7 +102,7 @@ If push is rejected due to remote having newer commits:
    - If `state` is `"CLOSED"` or `"MERGED"` → create a new PR
 
 2. **If no open PR exists**, create one:
-   - Extract info from commits: `git log origin/main..HEAD --oneline`
+   - Extract info from commits: `git log $(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' || echo main)..HEAD --oneline`
    - Generate PR title (short, imperative, <70 chars)
    - Generate PR body with:
      - Summary section

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,4 +1,11 @@
+---
+description: Review uncommitted changes, commits, branch diffs, or PRs with EdgeLab conventions
+agent: read
+subtask: true
+---
+
 You are a code reviewer for the EdgeLab Android project. Your job is to review code changes and provide actionable feedback.
+
 ---
 Input: $ARGUMENTS
 ---

--- a/.opencode/commands/review.md
+++ b/.opencode/commands/review.md
@@ -1,0 +1,84 @@
+You are a code reviewer for the EdgeLab Android project. Your job is to review code changes and provide actionable feedback.
+---
+Input: $ARGUMENTS
+---
+## Determining What to Review
+Based on the input provided, determine which type of review to perform:
+1. **No arguments (default)**: Review all uncommitted changes
+   - Run: `git diff` for unstaged changes
+   - Run: `git diff --cached` for staged changes
+   - Run: `git status --short` to identify untracked (net new) files
+2. **Commit hash** (40-char SHA or short hash): Review that specific commit
+   - Run: `git show $ARGUMENTS`
+3. **Branch name**: Compare current branch to the specified branch
+   - Run: `git diff $ARGUMENTS...HEAD`
+4. **PR URL or number** (contains "github.com" or "pull" or looks like a PR number): Review the pull request
+   - Run: `gh pr view $ARGUMENTS` to get PR context
+   - Run: `gh pr diff $ARGUMENTS` to get the diff
+Use best judgement when processing input.
+---
+## Gathering Context
+**Diffs alone are not enough.** After getting the diff, read the entire file(s) being modified to understand the full context. Code that looks wrong in isolation may be correct given surrounding logic—and vice versa.
+- Use the diff to identify which files changed
+- Use `git status --short` to identify untracked files, then read their full contents
+- Read the full file to understand existing patterns, control flow, and error handling
+- Check project convention files: `CLAUDE.md`, `AGENTS.md`, `docs/patterns.md`, `docs/testing.md`, `docs/architecture.md`
+---
+## EdgeLab-Specific Rules to Check
+When reviewing, verify compliance with these project-specific conventions (from `CLAUDE.md` and `docs/patterns.md`):
+- **Module boundaries**: `:data`, `:agent`, `:presentation` are pure Kotlin — zero `android.*` imports. Android code belongs only in `:core` and `:app:*`.
+- **DI**: Manual factory methods only (`CoreDependencies` + app `Dependencies`). No Hilt, Koin, Dagger.
+- **Formatting**: `./gradlew ktfmtFormat` must pass. Pre-commit hook enforces this.
+- **Immutable collections**: `ImmutableList`/`ImmutableMap` from `kotlinx.collections.immutable` required in all UiState data classes.
+- **ViewModel pattern**: Interface + impl in `:presentation`, Android wrapper in `:app:*`. Impl uses own `CoroutineScope`, not `viewModelScope`.
+- **CancellationException**: Must always be rethrown — never swallowed in catch blocks.
+- **Hardcoded dispatchers**: ViewModels must accept `ioDispatcher` param, not hardcode `Dispatchers.IO`.
+- **MutableStateFlow.update**: No side effects inside `update{}` lambda (may CAS-retry).
+- **Tests**: Every new ViewModel requires unit tests. Every new Composable screen requires `@Preview`.
+- **Dependencies**: All versions go in `gradle/libs.versions.toml`. Never hardcode in `build.gradle.kts`.
+---
+## What to Look For
+**Bugs** - Your primary focus.
+- Logic errors, off-by-one mistakes, incorrect conditionals
+- If-else guards: missing guards, incorrect branching, unreachable code paths
+- Edge cases: null/empty inputs, error conditions, race conditions
+- Security issues: injection, auth bypass, data exposure
+- Broken error handling that swallows failures, throws unexpectedly or returns error types that are not caught
+- CancellationException being swallowed (critical for this project)
+- Side effects inside `MutableStateFlow.update{}`
+- Android imports in `:data`, `:agent`, or `:presentation` modules
+
+**Structure** - Does the code fit the codebase?
+- Does it follow existing patterns and conventions?
+- Are there established abstractions it should use but doesn't?
+- Excessive nesting that could be flattened with early returns or extraction
+- Missing `@Preview` for new Composables
+- Missing unit tests for new ViewModels
+- Using `List` instead of `ImmutableList` in UiState
+
+**Performance** - Only flag if obviously problematic.
+- O(n²) on unbounded data, N+1 queries, blocking I/O on hot paths
+- Redundant `flowOn` when `withContext` handles dispatch
+
+**Behavior Changes** - If a behavioral change is introduced, raise it (especially if it's possibly unintentional).
+---
+## Before You Flag Something
+**Be certain.** If you're going to call something a bug, you need to be confident it actually is one.
+- Only review the changes - do not review pre-existing code that wasn't modified
+- Don't flag something as a bug if you're unsure - investigate first
+- Don't invent hypothetical problems - if an edge case matters, explain the realistic scenario where it breaks
+- If you need more context to be sure, read related files or use the explore agent to find how existing code handles similar problems
+
+**Don't be a zealot about style.** When checking code against conventions:
+- Verify the code is *actually* in violation. Don't complain about else statements if early returns are already being used correctly.
+- Some "violations" are acceptable when they're the simplest option. A `let` statement is fine if the alternative is convoluted.
+- Excessive nesting is a legitimate concern regardless of other style choices.
+- Don't flag style preferences as issues unless they clearly violate established project conventions.
+---
+## Output
+1. If there is a bug, be direct and clear about why it is a bug.
+2. Clearly communicate severity of issues. Do not overstate severity.
+3. Critiques should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+4. Your tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+5. Write so the reader can quickly understand the issue without reading too closely.
+6. AVOID flattery, do not give any comments that are not helpful to the reader. Avoid phrasing like "Great job ...", "Thanks for ...".

--- a/.opencode/skills/edgelab-workflows/SKILL.md
+++ b/.opencode/skills/edgelab-workflows/SKILL.md
@@ -28,4 +28,6 @@ When you add/rename/remove:
 
 | Command | Description |
 |---------|-------------|
+| `/review` | Review uncommitted changes, a commit, branch diff, or PR with EdgeLab-specific conventions |
+| `/commit-pr` | Commit, push, and create a GitHub PR (no Greptile loop) |
 | `/commit-pr-greptile` | Commit, create PR, poll Greptile review, auto-fix |

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelList.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelList.kt
@@ -105,7 +105,7 @@ private fun ModelListPreview() {
                         contextLength = 4096,
                         downloadUrl = "https://example.com/model.litertlm",
                         bundleFilename = "model1.litertlm",
-                        hardwareAcceleration = HardwareBackend.CPU_ONLY,
+                        hardwareAcceleration = HardwareBackend.NPU_SUPPORTED,
                     ),
                 isDownloaded = true,
                 downloadStatus = DownloadStatus.Completed,

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testing/TestScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testing/TestScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -31,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.monday8am.edgelab.explorer.Dependencies
-import com.monday8am.edgelab.data.model.HardwareBackend
 import com.monday8am.edgelab.data.model.ModelCatalog
 import com.monday8am.edgelab.data.model.ModelConfiguration
 import com.monday8am.edgelab.data.testing.TestDomain
@@ -85,8 +83,8 @@ fun TestScreen(
         selectedModel = state.selectedModel,
         isRunning = state.isRunning,
         isInitializing = state.isInitializing,
-        onRunTests = { useGpu, filter ->
-            viewModel.onUiAction(TestUiAction.RunTests(useGpu, filter))
+        onRunTests = { filter ->
+            viewModel.onUiAction(TestUiAction.RunTests(filter))
         },
         onCancelTests = { viewModel.onUiAction(TestUiAction.CancelTests) },
         onNavigateToTestDetails = onNavigateToTestDetails,
@@ -102,15 +100,12 @@ private fun TestContent(
     selectedModel: ModelConfiguration,
     isRunning: Boolean,
     isInitializing: Boolean,
-    onRunTests: (Boolean, TestDomain?) -> Unit,
+    onRunTests: (TestDomain?) -> Unit,
     onCancelTests: () -> Unit,
     onNavigateToTestDetails: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var filterDomain by rememberSaveable { mutableStateOf<TestDomain?>(null) }
-    var useGpuBackend by rememberSaveable {
-        mutableStateOf(selectedModel.hardwareAcceleration == HardwareBackend.GPU_SUPPORTED)
-    }
 
     val displayedTests =
         if (isRunning || filterDomain == null) testStatuses
@@ -132,9 +127,7 @@ private fun TestContent(
         // 1. Top Card with Model Info
         ModelInfoCard(
             model = selectedModel,
-            useGpu = useGpuBackend,
             isRunning = isRunning || isInitializing,
-            onBackendToggle = { useGpuBackend = it },
         )
 
         if (isInitializing) {
@@ -160,7 +153,7 @@ private fun TestContent(
                     isCancelling = true
                     onCancelTests()
                 } else {
-                    onRunTests(useGpuBackend, filterDomain)
+                    onRunTests(filterDomain)
                 }
             },
             enabled = !isInitializing && !isCancelling,
@@ -182,8 +175,6 @@ private fun TestContent(
 @Composable
 private fun ModelInfoCard(
     model: ModelConfiguration,
-    useGpu: Boolean,
-    onBackendToggle: (Boolean) -> Unit,
     isRunning: Boolean,
     modifier: Modifier = Modifier,
 ) {
@@ -202,20 +193,6 @@ private fun ModelInfoCard(
                 Text(
                     text = "${model.parameterCount}B params • ${model.contextLength} tokens",
                     style = MaterialTheme.typography.bodySmall,
-                )
-            }
-
-            // Right: CPU/GPU Toggle
-            Column(horizontalAlignment = Alignment.End, verticalArrangement = spacedBy(4.dp)) {
-                Text(
-                    text = if (useGpu) "GPU" else "CPU",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.primary,
-                )
-                Switch(
-                    checked = useGpu,
-                    enabled = !isRunning,
-                    onCheckedChange = { isChecked -> onBackendToggle(isChecked) },
                 )
             }
         }
@@ -315,7 +292,7 @@ private fun TestContentPreview() {
             selectedModel = ModelCatalog.DEFAULT,
             isRunning = false,
             isInitializing = true,
-            onRunTests = { _, _ -> },
+            onRunTests = { _ -> },
             onCancelTests = {},
             onNavigateToTestDetails = {},
         )

--- a/data/src/main/java/com/monday8am/edgelab/data/model/ModelConfiguration.kt
+++ b/data/src/main/java/com/monday8am/edgelab/data/model/ModelConfiguration.kt
@@ -2,7 +2,6 @@ package com.monday8am.edgelab.data.model
 
 @kotlinx.serialization.Serializable
 enum class HardwareBackend {
-    CPU_ONLY,
     GPU_SUPPORTED,
     NPU_SUPPORTED,
 }

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -156,10 +156,10 @@ For ViewModel-local state (not from a repository):
 
 ```kotlin
 private sealed class ViewModelState {
-    data class Idle(val lastUseGpu: Boolean = false) : ViewModelState()
-    data class Running(val useGpu: Boolean, val filterDomain: TestDomain?) : ViewModelState()
+    data object Idle : ViewModelState()
+    data class Running(val filterDomain: TestDomain?) : ViewModelState()
 }
-private val viewModelState = MutableStateFlow<ViewModelState>(ViewModelState.Idle())
+private val viewModelState = MutableStateFlow<ViewModelState>(ViewModelState.Idle)
 ```
 
 **Anti-patterns:**

--- a/presentation/src/main/kotlin/com/monday8am/edgelab/presentation/testing/TestViewModel.kt
+++ b/presentation/src/main/kotlin/com/monday8am/edgelab/presentation/testing/TestViewModel.kt
@@ -58,7 +58,7 @@ data class TestStatus(
 }
 
 sealed class TestUiAction {
-    data class RunTests(val useGpu: Boolean, val filterDomain: TestDomain?) : TestUiAction()
+    data class RunTests(val filterDomain: TestDomain?) : TestUiAction()
 
     data object CancelTests : TestUiAction()
 }
@@ -81,20 +81,13 @@ class TestViewModelImpl(
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
 
     private sealed class ViewModelState {
-        data class Idle(val lastUseGpu: Boolean = false) : ViewModelState()
+        data object Idle : ViewModelState()
 
-        data class Running(
-            val useGpu: Boolean,
-            val lastUseGpu: Boolean,
-            val filterDomain: TestDomain?,
-        ) : ViewModelState()
+        data class Running(val filterDomain: TestDomain?) : ViewModelState()
     }
 
     private var currentTestEngine: ToolCallingTestEngine? = null
-    private val viewModelState =
-        MutableStateFlow<ViewModelState>(
-            ViewModelState.Idle(initialModel.hardwareAcceleration == HardwareBackend.GPU_SUPPORTED)
-        )
+    private val viewModelState = MutableStateFlow<ViewModelState>(ViewModelState.Idle)
 
     // Load tests on init
     private val loadedTests: StateFlow<List<TestCase>> =
@@ -111,43 +104,28 @@ class TestViewModelImpl(
         combine(viewModelState, loadedTests) { state, tests -> state to tests }
             .flatMapLatest { (state, tests) ->
                 when (state) {
-                    is ViewModelState.Idle ->
-                        flow { emit(createIdleUiState(state.lastUseGpu, tests)) }
+                    is ViewModelState.Idle -> flow { emit(createIdleUiState(tests)) }
                     is ViewModelState.Running ->
-                        executeTests(
-                                useGpu = state.useGpu,
-                                lastUseGpu = state.lastUseGpu,
-                                filterDomain = state.filterDomain,
-                                testCases = tests,
-                            )
-                            .map { execState -> deriveUiState(execState, tests) }
+                        executeTests(filterDomain = state.filterDomain, testCases = tests).map {
+                            execState ->
+                            deriveUiState(execState, tests)
+                        }
                 }
             }
             .stateIn(
                 scope = scope,
                 started = SharingStarted.Eagerly,
-                initialValue = createIdleUiState(lastUseGpu = false, emptyList()),
+                initialValue = createIdleUiState(emptyList()),
             )
 
     override fun onUiAction(uiAction: TestUiAction) {
         when (uiAction) {
             is TestUiAction.RunTests -> {
-                val lastUseGpu =
-                    when (val current = viewModelState.value) {
-                        is ViewModelState.Idle -> current.lastUseGpu
-                        is ViewModelState.Running -> current.useGpu
-                    }
-                viewModelState.value =
-                    ViewModelState.Running(
-                        useGpu = uiAction.useGpu,
-                        lastUseGpu = lastUseGpu,
-                        filterDomain = uiAction.filterDomain,
-                    )
+                viewModelState.value = ViewModelState.Running(filterDomain = uiAction.filterDomain)
             }
             TestUiAction.CancelTests -> {
                 currentTestEngine?.cancel()
-                val lastUseGpu = (viewModelState.value as? ViewModelState.Running)?.useGpu ?: false
-                viewModelState.value = ViewModelState.Idle(lastUseGpu)
+                viewModelState.value = ViewModelState.Idle
             }
         }
     }
@@ -157,8 +135,6 @@ class TestViewModelImpl(
      * engine initialization, and test execution.
      */
     private fun executeTests(
-        useGpu: Boolean,
-        lastUseGpu: Boolean,
         filterDomain: TestDomain?,
         testCases: List<TestCase>,
     ): Flow<ExecutionState> = flow {
@@ -170,7 +146,7 @@ class TestViewModelImpl(
         val filteredTests =
             if (filterDomain == null) testCases else testCases.filter { it.domain == filterDomain }
 
-        val modelConfig = prepareModelConfig(useGpu, lastUseGpu)
+        val modelConfig = prepareModelConfig()
         val initialResults =
             TestResults(
                 statuses =
@@ -229,15 +205,8 @@ class TestViewModelImpl(
             .collect { emit(it) }
     }
 
-    private fun prepareModelConfig(useGpu: Boolean, lastUseGpu: Boolean): ModelConfiguration {
-        val newBackend = if (useGpu) HardwareBackend.GPU_SUPPORTED else HardwareBackend.CPU_ONLY
-
-        // Close session only if GPU setting changed
-        if (lastUseGpu != useGpu) {
-            inferenceEngine.closeSession()
-        }
-
-        return initialModel.copy(hardwareAcceleration = newBackend)
+    private fun prepareModelConfig(): ModelConfiguration {
+        return initialModel.copy(hardwareAcceleration = HardwareBackend.GPU_SUPPORTED)
     }
 
     private fun deriveUiState(state: ExecutionState, tests: List<TestCase>): TestUiState {
@@ -364,10 +333,9 @@ class TestViewModelImpl(
         return Pair(avgSpeed, totalTokens)
     }
 
-    private fun createIdleUiState(lastUseGpu: Boolean, tests: List<TestCase>): TestUiState {
-        val backend = if (lastUseGpu) HardwareBackend.GPU_SUPPORTED else HardwareBackend.CPU_ONLY
+    private fun createIdleUiState(tests: List<TestCase>): TestUiState {
         return TestUiState(
-            selectedModel = initialModel.copy(hardwareAcceleration = backend),
+            selectedModel = initialModel.copy(hardwareAcceleration = HardwareBackend.GPU_SUPPORTED),
             isRunning = false,
             isInitializing = false,
             frames = persistentMapOf(),

--- a/presentation/src/test/kotlin/com/monday8am/edgelab/presentation/testing/TestViewModelTest.kt
+++ b/presentation/src/test/kotlin/com/monday8am/edgelab/presentation/testing/TestViewModelTest.kt
@@ -39,8 +39,8 @@ class TestViewModelTest {
 
     @Test
     fun `TestUiAction RunTests should accept nullable domain filter`() {
-        val actionWithFilter = TestUiAction.RunTests(useGpu = true, filterDomain = TestDomain.YAZIO)
-        val actionWithoutFilter = TestUiAction.RunTests(useGpu = false, filterDomain = null)
+        val actionWithFilter = TestUiAction.RunTests(filterDomain = TestDomain.YAZIO)
+        val actionWithoutFilter = TestUiAction.RunTests(filterDomain = null)
 
         assertEquals(TestDomain.YAZIO, actionWithFilter.filterDomain)
         assertEquals(null, actionWithoutFilter.filterDomain)


### PR DESCRIPTION
## Summary

- Removes the unused \+CPU_ONLY\+ backend option from the testing flow
- Adds two new slash commands: `/review` and `/commit-pr`
- Updates docs and tests to match

## Changes

### Backend removal
- Remove `CPU_ONLY` from `HardwareBackend` enum
- Simplify `TestViewModel` by removing `useGpu` / `lastUseGpu` state machine fields
- Remove CPU/GPU `Switch` toggle from `TestScreen` and `ModelInfoCard`
- Update `TestViewModelTest` and `docs/patterns.md` for new `RunTests` signature

### New slash commands
- `/review` — reviews uncommitted changes with EdgeLab-specific conventions (bugs, structure, module boundaries, etc.)
- `/commit-pr` — lightweight commit-push-PR workflow without Greptile polling

### Docs
- Update `edgelab-workflows` skill to list all three commands