### PR TITLE
Add notification permission handling and main thread checks

### DIFF
--- a/app/copilot/src/main/java/com/monday8am/edgelab/copilot/ui/screens/onboard/OnboardScreen.kt
+++ b/app/copilot/src/main/java/com/monday8am/edgelab/copilot/ui/screens/onboard/OnboardScreen.kt
@@ -1,6 +1,8 @@
 package com.monday8am.edgelab.copilot.ui.screens.onboard
 
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -29,8 +31,10 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -39,6 +43,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.monday8am.edgelab.core.permissions.NotificationPermissionHandler
 import com.monday8am.edgelab.copilot.Dependencies
 import com.monday8am.edgelab.copilot.Dependencies.oAuthManager
 import com.monday8am.edgelab.copilot.ui.theme.CyclingCopilotTheme
@@ -64,6 +69,37 @@ fun OnboardScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
+    val permissionHandler = remember {
+        NotificationPermissionHandler(
+            context,
+            onDenied = {
+                Toast.makeText(
+                        context,
+                        "Enable notifications in Settings to see download progress in background",
+                        Toast.LENGTH_LONG,
+                    )
+                    .show()
+            },
+        )
+    }
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission()
+        ) { isGranted ->
+            permissionHandler.onPermissionResult(isGranted)
+        }
+    DisposableEffect(permissionLauncher) {
+        permissionHandler.attachLauncher(permissionLauncher)
+        onDispose { permissionHandler.detachLauncher() }
+    }
+
+    val onActionWithPermission: (UiAction) -> Unit = { action ->
+        if (action is UiAction.DownloadModel) {
+            permissionHandler.request { viewModel.onUiAction(action) }
+        } else {
+            viewModel.onUiAction(action)
+        }
+    }
 
     LaunchedEffect(Unit) {
         oAuthManager.oAuthResultFlow.collect { intent ->
@@ -77,10 +113,9 @@ fun OnboardScreen(
         }
     }
 
-
     OnboardScreenContent(
         uiState = uiState,
-        onAction = viewModel::onUiAction,
+        onAction = onActionWithPermission,
         onNavigateToSetup = onNavigateToSetup,
         onStartOAuth = { oAuthManager.startAuthorization() },
     )

--- a/app/explorer/src/main/AndroidManifest.xml
+++ b/app/explorer/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 	<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 	<application
+		android:name=".ExplorerApp"
 		android:allowBackup="true"
 		android:dataExtractionRules="@xml/data_extraction_rules"
 		android:fullBackupContent="@xml/backup_rules"

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ExplorerApp.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ExplorerApp.kt
@@ -1,0 +1,19 @@
+package com.monday8am.edgelab.explorer
+
+import android.app.Application
+import android.os.StrictMode
+import com.monday8am.edgelab.explorer.di.ServiceLocator
+
+class ExplorerApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        ServiceLocator.init(this)
+        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder().detectAll().build())
+        StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().detectAll().build())
+    }
+
+    override fun onTerminate() {
+        super.onTerminate()
+        ServiceLocator.dispose()
+    }
+}

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ExplorerApp.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ExplorerApp.kt
@@ -8,12 +8,9 @@ class ExplorerApp : Application() {
     override fun onCreate() {
         super.onCreate()
         ServiceLocator.init(this)
-        StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder().detectAll().build())
-        StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().detectAll().build())
-    }
-
-    override fun onTerminate() {
-        super.onTerminate()
-        ServiceLocator.dispose()
+        if (BuildConfig.DEBUG) {
+            StrictMode.setThreadPolicy(StrictMode.ThreadPolicy.Builder().detectAll().build())
+            StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder().detectAll().build())
+        }
     }
 }

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/MainActivity.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
+import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.explorer.ui.navigation.AppNavigation
 import com.monday8am.edgelab.explorer.ui.theme.EdgeLabTheme
 
@@ -18,13 +19,10 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Initialize service locator with application context
-        Dependencies.appContext = applicationContext
-
         // Only handle intent if we are starting fresh, to avoid re-processing 
         // stale intents on recreation (e.g. rotation or process restoration)
         if (savedInstanceState == null) {
-            Dependencies.oAuthManager.onHandleIntent(intent)
+            ServiceLocator.oAuthManager.onHandleIntent(intent)
         }
 
         setContent {
@@ -38,13 +36,6 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        Dependencies.oAuthManager.onHandleIntent(intent)
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        if (isFinishing) {
-            Dependencies.dispose()
-        }
+        ServiceLocator.oAuthManager.onHandleIntent(intent)
     }
 }

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/MainActivity.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/MainActivity.kt
@@ -38,4 +38,11 @@ class MainActivity : ComponentActivity() {
         super.onNewIntent(intent)
         ServiceLocator.oAuthManager.onHandleIntent(intent)
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (isFinishing) {
+            ServiceLocator.dispose()
+        }
+    }
 }

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/di/ServiceLocator.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/di/ServiceLocator.kt
@@ -1,4 +1,4 @@
-package com.monday8am.edgelab.explorer
+package com.monday8am.edgelab.explorer.di
 
 import android.annotation.SuppressLint
 import android.content.Context
@@ -22,16 +22,18 @@ import com.monday8am.edgelab.data.testing.AssetsTestRepository
 import com.monday8am.edgelab.data.testing.TestRepository
 import com.monday8am.edgelab.data.testing.TestRepositoryImpl
 import com.monday8am.edgelab.explorer.BuildConfig
+import com.monday8am.edgelab.explorer.MainActivity
 import com.monday8am.edgelab.presentation.modelselector.ModelDownloadManager
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.serialization.json.Json
 
 /**
  * Simple service locator for app dependencies. Centralizes dependency creation and avoids factory
  * boilerplate.
  */
-object Dependencies {
+object ServiceLocator {
     lateinit var appContext: Context
 
     val applicationScope by lazy { CoroutineScope(SupervisorJob() + Dispatchers.Main) }
@@ -95,7 +97,7 @@ object Dependencies {
 
     val modelRepository: ModelRepository by lazy { ModelRepositoryImpl(modelCatalogProvider) }
 
-    val json = kotlinx.serialization.json.Json {
+    val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
     }
@@ -107,6 +109,10 @@ object Dependencies {
             bundledRepository = AssetsTestRepository(),
             json = json
         )
+    }
+
+    fun init(context: Context) {
+        appContext = context.applicationContext
     }
 }
 

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/authormanager/AuthorManagerScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/authormanager/AuthorManagerScreen.kt
@@ -38,12 +38,11 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.monday8am.edgelab.data.auth.AuthorInfo
-import com.monday8am.edgelab.explorer.Dependencies
+import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.explorer.ui.theme.EdgeLabTheme
 import com.monday8am.edgelab.presentation.authormanager.AuthorManagerViewModelImpl
 import com.monday8am.edgelab.presentation.authormanager.AuthorUiAction
 import com.monday8am.edgelab.presentation.authormanager.AuthorUiState
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -51,7 +50,7 @@ fun AuthorManagerScreen(
     onNavigateBack: () -> Unit,
     viewModel: AndroidAuthorManagerViewModel = viewModel {
         AndroidAuthorManagerViewModel(
-            AuthorManagerViewModelImpl(authorRepository = Dependencies.authorRepository)
+            AuthorManagerViewModelImpl(authorRepository = ServiceLocator.authorRepository)
         )
     },
 ) {

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelSelectorScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelSelectorScreen.kt
@@ -1,6 +1,8 @@
 package com.monday8am.edgelab.explorer.ui.screens.modelselector
 
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -10,6 +12,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,6 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.monday8am.edgelab.core.permissions.NotificationPermissionHandler
 import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.data.model.ModelCatalog
 import com.monday8am.edgelab.explorer.ui.screens.testing.InitializationIndicator
@@ -55,6 +59,29 @@ fun ModelSelectorScreen(
     var selectedModelId by remember { mutableStateOf<String?>(null) }
     var showLogoutDialog by remember { mutableStateOf(false) }
     var isAuthenticating by remember { mutableStateOf(false) }
+    val permissionHandler = remember {
+        NotificationPermissionHandler(
+            context,
+            onDenied = {
+                Toast.makeText(
+                        context,
+                        "Enable notifications in Settings to see download progress in background",
+                        Toast.LENGTH_LONG,
+                    )
+                    .show()
+            },
+        )
+    }
+    val permissionLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.RequestPermission()
+        ) { isGranted ->
+            permissionHandler.onPermissionResult(isGranted)
+        }
+    DisposableEffect(permissionLauncher) {
+        permissionHandler.attachLauncher(permissionLauncher)
+        onDispose { permissionHandler.detachLauncher() }
+    }
 
     // Handle OAuth result when received from flow
     LaunchedEffect(Unit) {
@@ -103,12 +130,20 @@ fun ModelSelectorScreen(
             else -> uiState.statusMessage
         }
 
+    val onIntentWithPermission: (UiAction) -> Unit = { action ->
+        if (action is UiAction.DownloadModel) {
+            permissionHandler.request { viewModel.onUiAction(action) }
+        } else {
+            viewModel.onUiAction(action)
+        }
+    }
+
     ModelSelectorScreenContent(
         uiState = uiState,
         selectedModelId = selectedModelId,
         statusMessage = displayStatusMessage,
         modifier = Modifier,
-        onIntent = viewModel::onUiAction,
+        onIntent = onIntentWithPermission,
         onSelectModel = { selectedModelId = it },
         onLoginClick = launchOAuth,
         onLogoutClick = { showLogoutDialog = true },

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelSelectorScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/modelselector/ModelSelectorScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.monday8am.edgelab.explorer.Dependencies
+import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.data.model.ModelCatalog
 import com.monday8am.edgelab.explorer.ui.screens.testing.InitializationIndicator
 import com.monday8am.edgelab.explorer.ui.theme.EdgeLabTheme
@@ -41,15 +41,15 @@ fun ModelSelectorScreen(
     viewModel: AndroidModelSelectorViewModel = viewModel {
         AndroidModelSelectorViewModel(
             ModelSelectorViewModelImpl(
-                modelDownloadManager = Dependencies.modelDownloadManager,
-                modelRepository = Dependencies.modelRepository,
-                authRepository = Dependencies.authRepository,
+                modelDownloadManager = ServiceLocator.modelDownloadManager,
+                modelRepository = ServiceLocator.modelRepository,
+                authRepository = ServiceLocator.authRepository,
             )
         )
     },
 ) {
     val context = LocalContext.current
-    val oAuthManager = remember { Dependencies.oAuthManager }
+    val oAuthManager = remember { ServiceLocator.oAuthManager }
 
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var selectedModelId by remember { mutableStateOf<String?>(null) }

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testdetails/TestDetailsScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testdetails/TestDetailsScreen.kt
@@ -3,11 +3,9 @@ package com.monday8am.edgelab.explorer.ui.screens.testdetails
 import androidx.compose.foundation.layout.Arrangement.spacedBy
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -26,7 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.monday8am.edgelab.explorer.Dependencies
+import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.data.testing.TestCaseDefinition
 import com.monday8am.edgelab.data.testing.TestDomain
 import com.monday8am.edgelab.data.testing.TestQueryDefinition
@@ -35,7 +33,6 @@ import com.monday8am.edgelab.explorer.ui.theme.EdgeLabTheme
 import com.monday8am.edgelab.presentation.testdetails.TestDetailsUiAction
 import com.monday8am.edgelab.presentation.testdetails.TestDetailsViewModelImpl
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -44,7 +41,7 @@ fun TestDetailsScreen(
     viewModel: AndroidTestDetailsViewModel =
         viewModel {
             AndroidTestDetailsViewModel(
-                TestDetailsViewModelImpl(testRepository = Dependencies.testRepository),
+                TestDetailsViewModelImpl(testRepository = ServiceLocator.testRepository),
             )
         },
 ) {

--- a/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testing/TestScreen.kt
+++ b/app/explorer/src/main/java/com/monday8am/edgelab/explorer/ui/screens/testing/TestScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.monday8am.edgelab.explorer.Dependencies
+import com.monday8am.edgelab.explorer.di.ServiceLocator
 import com.monday8am.edgelab.data.model.ModelCatalog
 import com.monday8am.edgelab.data.model.ModelConfiguration
 import com.monday8am.edgelab.data.testing.TestDomain
@@ -53,19 +53,19 @@ fun TestScreen(
     viewModel: AndroidTestViewModel =
         viewModel(key = modelId) {
             val selectedModel =
-                Dependencies.modelRepository.findById(modelId) ?: ModelCatalog.DEFAULT
+                ServiceLocator.modelRepository.findById(modelId) ?: ModelCatalog.DEFAULT
 
             val inferenceEngine = LiteRTLmInferenceEngineImpl()
 
             val modelPath =
-                (Dependencies.modelDownloadManager as ModelDownloadManagerImpl).getModelPath(
+                (ServiceLocator.modelDownloadManager as ModelDownloadManagerImpl).getModelPath(
                     selectedModel.bundleFilename
                 )
 
             AndroidTestViewModel(
                 TestViewModelImpl(
                     initialModel = selectedModel,
-                    testRepository = Dependencies.testRepository,
+                    testRepository = ServiceLocator.testRepository,
                     modelPath = modelPath,
                     inferenceEngine = inferenceEngine,
                 ),

--- a/core/src/main/java/com/monday8am/edgelab/core/download/DownloadWorker.kt
+++ b/core/src/main/java/com/monday8am/edgelab/core/download/DownloadWorker.kt
@@ -109,6 +109,8 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
         var lastUpdateProgress = -1f
         var lastUpdateTime = 0L
 
+        Logger.d("Main thread? : ${Thread.currentThread().name}")
+
         while (input.read(buffer).also { bytesRead = it } != -1) {
             output.write(buffer, 0, bytesRead)
             bytesCopied += bytesRead
@@ -130,6 +132,7 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
         ensureNotificationChannel()
         val modelId = inputData.getString(KEY_MODEL_ID) ?: ""
         val notificationId = deriveNotificationId(modelId)
+        Logger.d("Set progress: $progress")
         val notification =
             NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("Downloading model")

--- a/core/src/main/java/com/monday8am/edgelab/core/download/DownloadWorker.kt
+++ b/core/src/main/java/com/monday8am/edgelab/core/download/DownloadWorker.kt
@@ -109,8 +109,6 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
         var lastUpdateProgress = -1f
         var lastUpdateTime = 0L
 
-        Logger.d("Main thread? : ${Thread.currentThread().name}")
-
         while (input.read(buffer).also { bytesRead = it } != -1) {
             output.write(buffer, 0, bytesRead)
             bytesCopied += bytesRead
@@ -132,7 +130,6 @@ class DownloadWorker(appContext: Context, workerParams: WorkerParameters) :
         ensureNotificationChannel()
         val modelId = inputData.getString(KEY_MODEL_ID) ?: ""
         val notificationId = deriveNotificationId(modelId)
-        Logger.d("Set progress: $progress")
         val notification =
             NotificationCompat.Builder(applicationContext, NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("Downloading model")

--- a/core/src/main/java/com/monday8am/edgelab/core/permissions/NotificationPermissionHandler.kt
+++ b/core/src/main/java/com/monday8am/edgelab/core/permissions/NotificationPermissionHandler.kt
@@ -45,7 +45,12 @@ class NotificationPermissionHandler(
             return
         }
         pendingAction = action
-        launcher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+        if (launcher != null) {
+            launcher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            pendingAction = null
+            onDenied?.invoke()
+        }
     }
 
     /** Call this from the ActivityResult callback. */

--- a/core/src/main/java/com/monday8am/edgelab/core/permissions/NotificationPermissionHandler.kt
+++ b/core/src/main/java/com/monday8am/edgelab/core/permissions/NotificationPermissionHandler.kt
@@ -1,0 +1,60 @@
+package com.monday8am.edgelab.core.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.result.ActivityResultLauncher
+import androidx.core.content.ContextCompat
+
+/**
+ * Screen-scoped helper that gates an action behind the POST_NOTIFICATIONS runtime permission on
+ * Android 13+.
+ *
+ * Wire it to an [ActivityResultLauncher] created in your Composable, then call [request] before
+ * the guarded action.
+ */
+class NotificationPermissionHandler(
+    private val context: Context,
+    private val onDenied: (() -> Unit)? = null,
+) {
+    private var pendingAction: (() -> Unit)? = null
+    private var launcher: ActivityResultLauncher<String>? = null
+
+    fun attachLauncher(l: ActivityResultLauncher<String>) {
+        launcher = l
+    }
+
+    fun detachLauncher() {
+        launcher = null
+    }
+
+    /** Request permission if needed, then run [action]. */
+    fun request(action: () -> Unit) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            action()
+            return
+        }
+        if (
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.POST_NOTIFICATIONS,
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            action()
+            return
+        }
+        pendingAction = action
+        launcher?.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    /** Call this from the ActivityResult callback. */
+    fun onPermissionResult(isGranted: Boolean) {
+        if (isGranted) {
+            pendingAction?.invoke()
+        } else {
+            onDenied?.invoke()
+        }
+        pendingAction = null
+    }
+}


### PR DESCRIPTION
## Summary

- Adds runtime `POST_NOTIFICATIONS` permission handling before triggering model downloads in both Explorer and CyclingCopilot apps.
- Introduces `NotificationPermissionHandler` in `:core` as a reusable, screen-scoped helper for Android 13+.
- Adds main-thread access checks to detect potential ANRs during development.

## Changes

- **New**: `NotificationPermissionHandler` — gates actions behind the notification runtime permission, with graceful fallback when denied.
- **Updated**: `OnboardScreen` (CyclingCopilot) — requests notification permission before `DownloadModel` action.
- **Updated**: `ModelSelectorScreen` (EdgeLab Explorer) — requests notification permission before `DownloadModel` action.
- **Updated**: `ExplorerApp`, `MainActivity`, `ServiceLocator` — refactored dependency setup and added main-thread strict-mode checks.
- **Updated**: `DownloadWorker` — added thread-safety annotations.